### PR TITLE
19 load example activities from the educationplatform examples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "educationplatform"]
 	path = educationplatform
 	url = ../educationplatform.git
-[submodule "educationplatform-examples"]
-	path = educationplatform-examples
-	url = ../educationplatform-examples.git
 [submodule "platformtools"]
 	path = platformtools
 	url = ../platformtools.git

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Any bugs, feature requests, or suggestions can be added to the [issue tracker](h
 
 If using a linux based virtual machine, the minimum recommended settings of 3GB system memory and 30GB virtual disk should be used.
 
+### Mac Preconfiguration
+Docker on Mac defaults to 2GB of system memory which is not sufficient since Docker uses virtualisation to run containers on Mac. The minimum recommended value to use as the minimum Docker memory limit is 6GB. See the [Docker desktop documentation](https://docs.docker.com/desktop/settings/mac/) for further details on how to configure this.
+
 ### Windows Preconfiguration
 If using Windows to run the platform, a few additional steps are required.
 
@@ -84,6 +87,9 @@ If a 403 forbidden permissions error is encountered, the permission of the files
 ``` 
 chmod -R 755 {public,educationplatform-examples} 
 ```
+
+
+> Note - that browsers cache the platform pages so if changes are made to an activity or its files hard refresh should be used to reload the page by pressing `ctrl+F5` or `cmd+shift+R`. 
 
 ## Stopping the platform
 

--- a/activities/README.md
+++ b/activities/README.md
@@ -1,0 +1,3 @@
+Create activites for testing here. They will be accessible at http://127.0.0.1:8082 when the platform is running.
+
+For example activities see https://github.com/mdenet/educationplatform-examples

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         volumes:
             - ./config/nginx.conf:/etc/nginx/nginx.conf
             - ./config/default.conf:/etc/nginx/conf.d/default.conf
-            - ./educationplatform-examples:/usr/share/nginx/html
+            - ./activities:/usr/share/nginx/html
 
     mdenet-tool-epsilon:
         image: mdenet-tool-epsilon:latest

--- a/public/list.html
+++ b/public/list.html
@@ -8,8 +8,9 @@
 <h1>MDENet Education Platform - Activity List</h1>
 The Education Platform is now running. Select an activity from the list to begin.
 <ol>
-  <li><a href="http://127.0.0.1:8080/?activity-eol&activities=http://127.0.0.1:8082/epsilon-example/epsilon-example_activity.json">Epsilon - EOL EVL and ETL</a></li>
-  <li><a href="http://127.0.0.1:8080/?activities=http://127.0.0.1:8082/ocl/ocl_activity.json">OCL Validation</a></li>
+  <li><a href="http://127.0.0.1:8080/?activities=https://raw.githubusercontent.com/mdenet/educationplatform-examples/main/epsilon-example/epsilon-example_activity.yml">Epsilon - EOL EVL and ETL</a></li>
+  <li><a href="http://127.0.0.1:8080/?activities=https://raw.githubusercontent.com/mdenet/educationplatform-examples/main/ocl/ocl_activity.json">OCL Validation</a></li>
+  <li><a href="http://127.0.0.1:8080/?activities=https://raw.githubusercontent.com/mdenet/educationplatform-examples/main/xtext-turtles/xtext_activity.json">Xtext - Language Workbench</a></li>
 </ol>
 
 </body>


### PR DESCRIPTION
Removed educationplatfrom-examples  submodule and example activities are now loaded from the educationplatfrom-example repo urls.