### PR TITLE
Hide the login box by default and only show it for private repo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
 <body class="h-100" onresize="fit()" onload="fit();updateGutterVisibility();">
     <div id="preloader"><img src="images/preloader.gif" width="100px"></div>
 
-    <div id="login" style="display:inline">
+    <div id="login" style="display:none">
         <h2>Login</h2>
         <p> 
             <button id="btnlogin" class="loginbutton" type="button" onclick="">Sign in with github</button> <br>


### PR DESCRIPTION
Hide the login box by default and only show it when a private repo is given. This prevents the login box's brief display when loading a private repo mdenet/educationplatform-docker#2.