### PR TITLE
Use workspace top-level package loc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
         ports:
             - "8080:80"
         build:
-          context: educationplatform/platform
+          context: educationplatform
+          dockerfile: ./platform/Dockerfile
         
         volumes:
             - ./config/list-redirect.conf:/etc/nginx/conf.d/default.conf
@@ -14,7 +15,8 @@ services:
     mdenet-tokenserver:
         image: mdenet-tokenserver:latest
         build:
-          context: educationplatform/tokenserver
+          context: educationplatform
+          dockerfile: ./tokenserver/Dockerfile
         ports:
             - "${TS_PORT}:${TS_PORT}"
         environment:


### PR DESCRIPTION
When looking to resolve the flagged security issues, the platform and tokenserver should use the top-level workspace package lock rather than individually generated workspace-level package lock so that overrides can be used to ensure dependencies versions are configurable.

Updated platform and tokenserver context to enable the top-level package lock to be used.