### PR TITLE
Switch to using the epsilon micronaught service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,14 @@ services:
             - ./config/default.conf:/etc/nginx/conf.d/default.conf
             - ./activities:/usr/share/nginx/html
 
+    mdenet-tool-conversion:
+       image: mde-tool-conversion:latest
+       ports:
+          - "8069:80"
+       build:
+         context: platformtools
+         dockerfile: static.conversion/Dockerfile
+
     mdenet-tool-epsilon:
         image: ghcr.io/epsilonlabs/playground-micronaut:0.1
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,9 @@ services:
             - ./activities:/usr/share/nginx/html
 
     mdenet-tool-epsilon:
-        image: mdenet-tool-epsilon:latest
+        image: ghcr.io/epsilonlabs/playground-micronaut:0.1
         ports:
-            - "8070:80"
-        build:
-          context: platformtools
-          dockerfile: static.epsilon/Dockerfile
+            - "8070:8080"
 
     mdenet-tool-emfatic:
         image: mdenet-tool-emfatic:latest


### PR DESCRIPTION
For mdenet/platformtools#32, switched the epsilon tool to use the micronaught docker image and the mdenet conversion tool that contains the flexmitoxmi conversion function used for the ocl example activity.
 
PR mdenet/platformtools#33 should be completed and merged before this. 