### PR TITLE
Feedback survey url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,14 @@ services:
         environment:
             - TOKEN_SERVER_URL
             - WEBSOCKETS_URI
+            - FEEDBACK_SURVEY_URL
         build:
           context: educationplatform
           dockerfile: ./platform/Dockerfile
           args: 
               - TOKEN_SERVER_URL=$TOKEN_SERVER_URL
               - WEBSOCKETS_URI=$WEBSOCKETS_URI
+              - FEEDBACK_SURVEY_URL=$FEEDBACK_SURVEY_URL
         volumes:
             - ./config/list-redirect.conf:/etc/nginx/conf.d/default.conf
             - ./public/list.html:/usr/share/nginx/html/list.html


### PR DESCRIPTION
Following the fix in education platform, this adds the FEEDBACK_SURVEY_URL to docker-compose.yml.