### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: build
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/mdenet/educationplatform-docker/security/code-scanning/1](https://github.com/mdenet/educationplatform-docker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow primarily involves checking out the repository and running Docker commands, it only requires `contents: read` permissions. This change will explicitly limit the permissions of the `GITHUB_TOKEN` to read-only access to repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
